### PR TITLE
Support Form logging only on Error

### DIFF
--- a/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
+++ b/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SerilogWeb.Classic
+{
+    /// <summary>
+    /// Describes options for logging form request data
+    /// </summary>
+    public enum LogPostedFormDataOption
+    {
+        /// <summary>
+        /// Posted form values are never logged
+        /// </summary>
+        Never,
+        /// <summary>
+        /// Posted form values are always logged
+        /// </summary>
+        Always,
+        /// <summary>
+        /// Posted form values are logged if Response.StatusCode >= 500
+        /// </summary>
+        OnlyOnError
+    }
+}

--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Classic\Enrichers\HttpRequestUserAgentEnricher.cs" />
     <Compile Include="Classic\Enrichers\HttpSessionIdEnricher.cs" />
     <Compile Include="Classic\Enrichers\UserNameEnricher.cs" />
+    <Compile Include="Classic\LogPostedFormDataOption.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>


### PR DESCRIPTION
This PR changes `DebugLogPostedFormData` into an Enum, introducing the option to only log form data in the event of an error.  An error is determined by a Response code >= 500.

This also introduces the ability to configure the logging level at which form data is recorded, matching the way the request logging level can be varied.

To use:

```
ApplicationLifecycleModule.LogPostedFormData = LogPostedFormDataOption.OnlyOnError;
ApplicationLifecycleModule.FormDataLoggingLevel = LogEventLevel.Trace;
```

This is a breaking change, because it renames and changes the datatype of the property `DebugLogPostedFormData`.
