### PR TITLE
Copyright Headers

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostIPEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostIPEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostNameEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostNameEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestIdEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestIdEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestNumberEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestNumberEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestRawUrlEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestRawUrlEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestTraceIdEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestTraceIdEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestTypeEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestTypeEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUrlEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUrlEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUrlReferrerEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUrlReferrerEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUserAgentEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUserAgentEnricher.cs
@@ -1,4 +1,4 @@
-// Copyright 2014 Serilog Contributors
+// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpSessionIdEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpSessionIdEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2015 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/SerilogWeb.Classic/Properties/AssemblyInfo.cs
+++ b/src/SerilogWeb.Classic/Properties/AssemblyInfo.cs
@@ -4,6 +4,6 @@ using SerilogWeb.Classic;
 
 [assembly: AssemblyTitle("Serilog.Web")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2013")]
+[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2015")]
 
 [assembly: PreApplicationStartMethod(typeof(ApplicationLifecycleModule), "Register")]


### PR DESCRIPTION
Perhaps OCD, but the copyright dates should match across the assembly headers.

Some files didn't have it, but I just left them as-is.
