### PR TITLE
Update NuGet spec to match the references that build the project

### DIFF
--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
     <tags>serilog logging aspnet</tags>
     <dependencies>
-      <dependency id="Serilog" version="1.4.204" />
+      <dependency id="Serilog" version="1.5.7" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Another one I'm probably wrong about, but shouldn't the nuget specification version for Serilog match the package version the library is built against? I guess there aren't any breaking changes between 1.4.204 and 1.5.7, so there shouldn't be issues there.

Then again, I don't know if bumping the required version then requires bumping the serilog-web-classic package version too?

Ahh, package management.
