### PR TITLE
Default to providing a logger context for events

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -45,7 +45,7 @@ namespace SerilogWeb.Classic
         {
             get
             {
-                return _logger ?? Log.Logger;
+                return _logger ?? Log.Logger.ForContext<ApplicationLifecycleModule>();
             }
             set
             {

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -45,7 +45,7 @@ namespace SerilogWeb.Classic
         {
             get
             {
-                return _logger ?? Log.Logger.ForContext<ApplicationLifecycleModule>();
+                return (_logger ?? Log.Logger).ForContext<ApplicationLifecycleModule>();
             }
             set
             {


### PR DESCRIPTION
Default to providing the module class as the log context so we can filter out the day-to-day web surfing log entries.
