### PR TITLE
Adding property for minumum HTTP status failure

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -31,20 +31,20 @@ namespace SerilogWeb.Classic
     {
         private const string StopWatchKey = "SerilogWeb.Classic.ApplicationLifecycleModule.StopWatch";
 
-        static volatile LogPostedFormDataOption _logPostedFormData = LogPostedFormDataOption.Never;
-        static volatile bool _isEnabled = true;
-        static volatile bool _filterPasswordsInFormData = true;
-        static volatile IEnumerable<string> _filteredKeywords = new[] { "password" };
-        static volatile LogEventLevel _requestLoggingLevel = LogEventLevel.Information;
-        static volatile LogEventLevel _formDataLoggingLevel = LogEventLevel.Debug;
-        static volatile ConcurrentBag<Func<HttpContext, bool>> _requestPredicates = new ConcurrentBag<Func<HttpContext, bool>>();
+        static LogPostedFormDataOption _logPostedFormData = LogPostedFormDataOption.Never;
+        static bool _isEnabled = true;
+        static bool _filterPasswordsInFormData = true;
+        static IEnumerable<string> _filteredKeywords = new[] { "password" };
+        static LogEventLevel _requestLoggingLevel = LogEventLevel.Information;
+        static LogEventLevel _formDataLoggingLevel = LogEventLevel.Debug;
+        static readonly ConcurrentBag<Func<HttpContext, bool>> _requestPredicates = new ConcurrentBag<Func<HttpContext, bool>>();
 
         #pragma warning disable 612 // allow obsolete call to keep backwards compatability
-        static volatile ConcurrentBag<Func<HttpContext, bool>> _shouldLogPostedFormDataPredicates = new ConcurrentBag<Func<HttpContext, bool>> { context => LogPostedFormData == LogPostedFormDataOption.Always ||
+        static readonly ConcurrentBag<Func<HttpContext, bool>> _shouldLogPostedFormDataPredicates = new ConcurrentBag<Func<HttpContext, bool>> { context => LogPostedFormData == LogPostedFormDataOption.Always ||
                                                                                                                                                   (LogPostedFormData == LogPostedFormDataOption.OnlyOnError && context.Response.StatusCode >= 500)};
         #pragma warning restore 612
 
-        static volatile ILogger _logger;
+        static ILogger _logger;
 
         /// <summary>
         /// The globally-shared logger.

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -39,7 +39,7 @@ namespace SerilogWeb.Classic
 
         #pragma warning disable 612 // allow obsolete call to keep backwards compatability
         static volatile Func<HttpContext, bool> _shouldLogPostedFormData = context => (LogPostedFormData == LogPostedFormDataOption.Always ||
-            (LogPostedFormData == LogPostedFormDataOption.OnlyOnError && HttpContext.Current.Response.StatusCode >= 500));
+            (LogPostedFormData == LogPostedFormDataOption.OnlyOnError && context.Response.StatusCode >= 500));
         #pragma warning restore 612
 
         static volatile ILogger _logger;

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -147,7 +147,13 @@ namespace SerilogWeb.Classic
         public static Func<HttpContext, bool> ShouldLogPostedFormData
         {
             get { return _shouldLogPostedFormData; }
-            set { _shouldLogPostedFormData = value; }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                _shouldLogPostedFormData = value;
+            }
         }
 
         /// <summary>

--- a/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
+++ b/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
@@ -24,7 +24,7 @@ namespace SerilogWeb.Classic
         /// </summary>
         OnlyOnError,
         /// <summary>
-        /// Uses the custom predicate defined by <see cref="ApplicationLifecycleModule.ShouldLogPostedFormDataPredicate"/>
+        /// Uses the custom predicate defined by <see cref="ApplicationLifecycleModule.ShouldLogPostedFormData"/>
         /// to determine if posted form values are logged
         /// </summary>
         OnMatch

--- a/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
+++ b/src/SerilogWeb.Classic/Classic/LogPostedFormDataOption.cs
@@ -22,6 +22,11 @@ namespace SerilogWeb.Classic
         /// <summary>
         /// Posted form values are logged if Response.StatusCode >= 500
         /// </summary>
-        OnlyOnError
+        OnlyOnError,
+        /// <summary>
+        /// Uses the custom predicate defined by <see cref="ApplicationLifecycleModule.ShouldLogPostedFormDataPredicate"/>
+        /// to determine if posted form values are logged
+        /// </summary>
+        OnMatch
     }
 }

--- a/test/SerilogWeb.Test/Default.aspx
+++ b/test/SerilogWeb.Test/Default.aspx
@@ -9,6 +9,8 @@
 <body>
     <form id="form1" runat="server">
     <div>
+        <asp:TextBox runat="server" Text="My Content"></asp:TextBox>
+        <button runat="server" OnServerClick="Fail">Click me</button>
     
     </div>
     </form>

--- a/test/SerilogWeb.Test/Default.aspx.cs
+++ b/test/SerilogWeb.Test/Default.aspx.cs
@@ -11,5 +11,10 @@ namespace SerilogWeb.Test
 
             // throw new InvalidOperationException("Unlucky this time!");
         }
+
+        protected void Fail(object sender, EventArgs e)
+        {
+            throw new InvalidOperationException("Kablooey");
+        }
     }
 }

--- a/test/SerilogWeb.Test/Global.asax.cs
+++ b/test/SerilogWeb.Test/Global.asax.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Serilog;
+using Serilog.Events;
+using SerilogWeb.Classic;
 
 namespace SerilogWeb.Test
 {
@@ -7,6 +9,10 @@ namespace SerilogWeb.Test
     {
         protected void Application_Start(object sender, EventArgs e)
         {
+            ApplicationLifecycleModule.FormDataLoggingLevel = LogEventLevel.Debug;
+            ApplicationLifecycleModule.ShouldLogPostedFormDataPredicates.Add(
+                context => context.Response.StatusCode >= 400);
+
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Trace()

--- a/test/SerilogWeb.Test/Global.asax.cs
+++ b/test/SerilogWeb.Test/Global.asax.cs
@@ -11,9 +11,9 @@ namespace SerilogWeb.Test
         {
             ApplicationLifecycleModule.FormDataLoggingLevel = LogEventLevel.Debug;
             ApplicationLifecycleModule.LogPostedFormData = LogPostedFormDataOption.OnMatch;
-            ApplicationLifecycleModule.ShouldLogPostedFormDataPredicate = context => context.Response.StatusCode >= 400;
+            ApplicationLifecycleModule.ShouldLogPostedFormData = context => context.Response.StatusCode >= 400;
 
-            ApplicationLifecycleModule.RequestFilterPredicates.Add(context => context.Request.QueryString["nolog"] == "true");
+            ApplicationLifecycleModule.RequestFilter = context => context.Request.Url.PathAndQuery.StartsWith("/__browserLink");
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()

--- a/test/SerilogWeb.Test/Global.asax.cs
+++ b/test/SerilogWeb.Test/Global.asax.cs
@@ -10,8 +10,10 @@ namespace SerilogWeb.Test
         protected void Application_Start(object sender, EventArgs e)
         {
             ApplicationLifecycleModule.FormDataLoggingLevel = LogEventLevel.Debug;
-            ApplicationLifecycleModule.ShouldLogPostedFormDataPredicates.Add(
-                context => context.Response.StatusCode >= 400);
+            ApplicationLifecycleModule.LogPostedFormData = LogPostedFormDataOption.OnMatch;
+            ApplicationLifecycleModule.ShouldLogPostedFormDataPredicate = context => context.Response.StatusCode >= 400;
+
+            ApplicationLifecycleModule.RequestFilterPredicates.Add(context => context.Request.QueryString["nolog"] == "true");
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()


### PR DESCRIPTION
I was hoping to log bad data posted to our WebAPI but we return a 400 when we encounter validation errors. Needed a way tweak what was considered a failure.

Also thought about adding another option to LogPostedFormDataOption that would indicate logging client (4xx) and server errors (5xx) but this felt like it was the least intrusive to the current API.
