### PR TITLE
Log webapi exceptions

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -159,7 +159,9 @@ namespace SerilogWeb.Classic
                         return;
 
                     var error = application.Server.GetLastError();
-                    var level = error != null ? LogEventLevel.Error : _requestLoggingLevel;
+                    var level = error != null || 
+                        (application.Response.StatusCode >= 400 && application.Response.StatusCode <= 599) 
+                        ? LogEventLevel.Error : _requestLoggingLevel;
 
                     var logger = Logger;
                     if (ShouldLogFormData)

--- a/src/SerilogWeb.Classic/Classic/ExceptionLogger.cs
+++ b/src/SerilogWeb.Classic/Classic/ExceptionLogger.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Http;
+using System.Web.Http.ExceptionHandling;
+using Serilog;
+
+namespace SerilogWeb.Classic
+{
+    /// <summary>
+    /// Add the following line in Global.asax.cs
+    /// to log WebApi faults
+    /// <code>
+    /// protected void Application_Start()
+    ///   {
+    ///       GlobalConfiguration.Configure(SerilogWeb.Classic.ExceptionLogger.Register);
+    ///   }
+    /// </code>
+    /// </summary>
+    public class ExceptionLogger : IExceptionLogger
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static Action<HttpConfiguration> Register
+            => c => c.Services.Add(typeof (IExceptionLogger),
+                new ExceptionLogger());
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task LogAsync(ExceptionLoggerContext context, CancellationToken cancellationToken)
+        {
+            HttpContext.Current.AddError(context.Exception);
+            
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/SerilogWeb.Classic/Classic/ExceptionLogger.cs
+++ b/src/SerilogWeb.Classic/Classic/ExceptionLogger.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.ExceptionHandling;
-using Serilog;
 
 namespace SerilogWeb.Classic
 {

--- a/src/SerilogWeb.Classic/Classic/WebApiExceptionLogger.cs
+++ b/src/SerilogWeb.Classic/Classic/WebApiExceptionLogger.cs
@@ -13,11 +13,11 @@ namespace SerilogWeb.Classic
     /// <code>
     /// protected void Application_Start()
     ///   {
-    ///       GlobalConfiguration.Configure(SerilogWeb.Classic.ExceptionLogger.Register);
+    ///       GlobalConfiguration.Configure(SerilogWeb.Classic.WebApiExceptionLogger.Register);
     ///   }
     /// </code>
     /// </summary>
-    public class ExceptionLogger : IExceptionLogger
+    public class WebApiExceptionLogger : IExceptionLogger
     {
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace SerilogWeb.Classic
         /// </summary>
         public static Action<HttpConfiguration> Register
             => c => c.Services.Add(typeof (IExceptionLogger),
-                new ExceptionLogger());
+                new WebApiExceptionLogger());
 
         /// <summary>
         /// 

--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
@@ -74,7 +74,7 @@
     <Compile Include="Classic\Enrichers\HttpRequestUserAgentEnricher.cs" />
     <Compile Include="Classic\Enrichers\HttpSessionIdEnricher.cs" />
     <Compile Include="Classic\Enrichers\UserNameEnricher.cs" />
-    <Compile Include="Classic\ExceptionLogger.cs" />
+    <Compile Include="Classic\WebApiExceptionLogger.cs" />
     <Compile Include="Classic\LogPostedFormDataOption.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">

--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Classic\Enrichers\HttpRequestUserAgentEnricher.cs" />
     <Compile Include="Classic\Enrichers\HttpSessionIdEnricher.cs" />
     <Compile Include="Classic\Enrichers\UserNameEnricher.cs" />
+    <Compile Include="Classic\ExceptionLogger.cs" />
     <Compile Include="Classic\LogPostedFormDataOption.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">

--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.csproj
@@ -49,6 +49,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\WebApplication2\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SerilogWeb.Classic/packages.config
+++ b/src/SerilogWeb.Classic/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi Nick,

I've got a fix for the issue where WebApi exceptions were not getting logged. However, to do it within the SerilogWeb.Classic package requires an additional dependency on `WebApi.Core`, which breaks the principle for pay only when you need it. 

The alternatives are
-  a single file which the user adds to their project, 
- or a bit of documentation in the wiki
- or a separate NuGet package.

What do you think?
