### PR TITLE
Log requests at error level if 500+, even if no exception can be detected

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: '{build}'
+build_script:
+- ps: ./Build.ps1 -majorMinor "2.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+artifacts:
+- path: SerilogWeb.*.nupkg
+deploy:
+- provider: NuGet
+  api_key:
+    secure: RKWJyeIQtpcfdYoghDQ46d1BnP9ouE5bifxbxVLpV1jW/hfu9BartYv9RYi5kZch
+  skip_symbols: true
+  on:
+    branch: master
+    

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -28,7 +28,7 @@ namespace SerilogWeb.Classic
     /// </summary>
     public class ApplicationLifecycleModule : IHttpModule
     {
-        private const string StopWatchKey = "SerilogWeb.Classic.ApplicationLifecycleModule.StopWatch";
+        const string StopWatchKey = "SerilogWeb.Classic.ApplicationLifecycleModule.StopWatch";
 
         static LogPostedFormDataOption _logPostedFormData = LogPostedFormDataOption.Never;
         static bool _isEnabled = true;
@@ -198,8 +198,10 @@ namespace SerilogWeb.Classic
                     if (request == null || _requestFilter(application.Context))
                         return;
 
+                    var response = HttpContextCurrent.Response;
+
                     var error = application.Server.GetLastError();
-                    var level = error != null ? LogEventLevel.Error : _requestLoggingLevel;
+                    var level = error != null || response?.StatusCode >= 500 ? LogEventLevel.Error : _requestLoggingLevel;
 
                     var logger = Logger;
                     if (logger.IsEnabled(_formDataLoggingLevel) && FormLoggingStrategy(application.Context))

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -198,10 +198,8 @@ namespace SerilogWeb.Classic
                     if (request == null || _requestFilter(application.Context))
                         return;
 
-                    var response = HttpContextCurrent.Response;
-
                     var error = application.Server.GetLastError();
-                    var level = error != null || response?.StatusCode >= 500 ? LogEventLevel.Error : _requestLoggingLevel;
+                    var level = error != null || application.Response.StatusCode >= 500 ? LogEventLevel.Error : _requestLoggingLevel;
 
                     var logger = Logger;
                     if (logger.IsEnabled(_formDataLoggingLevel) && FormLoggingStrategy(application.Context))

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpContextCurrent.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpContextCurrent.cs
@@ -37,24 +37,5 @@ namespace SerilogWeb.Classic.Enrichers
                 }
             }
         }
-
-        [DebuggerNonUserCode]
-        internal static HttpResponse Response
-        {
-            get
-            {
-                HttpContext httpContext = HttpContext.Current;
-                if (httpContext == null)
-                    return null;
-                try
-                {
-                    return httpContext.Response;
-                }
-                catch (HttpException)
-                {
-                    return null;
-                }
-            }
-        }
     }
 }

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpContextCurrent.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpContextCurrent.cs
@@ -7,7 +7,7 @@ namespace SerilogWeb.Classic.Enrichers
     /// This helper class is used to handle special case introduced by ASP.NET integrated pipeline 
     /// when HttpContextCurrent.Request may throw instead of returning null.
     /// </summary>
-    internal static class HttpContextCurrent
+    static class HttpContextCurrent
     {
         /// <summary>
         /// Gets the <see cref="T:System.Web.HttpRequest"/> object for the current HTTP request.
@@ -16,7 +16,7 @@ namespace SerilogWeb.Classic.Enrichers
         /// <returns>
         /// The current HTTP request.
         /// </returns>
-        
+
         // Attribute added to suppress possible exceptions from breaking into debugger when running in "Just my code" mode.
         [DebuggerNonUserCode]
         internal static HttpRequest Request
@@ -33,6 +33,25 @@ namespace SerilogWeb.Classic.Enrichers
                 catch (HttpException)
                 {
                     // No need to check the type of the exception - only one exception can be thrown by .Request and we want to ignore it.
+                    return null;
+                }
+            }
+        }
+
+        [DebuggerNonUserCode]
+        internal static HttpResponse Response
+        {
+            get
+            {
+                HttpContext httpContext = HttpContext.Current;
+                if (httpContext == null)
+                    return null;
+                try
+                {
+                    return httpContext.Response;
+                }
+                catch (HttpException)
+                {
                     return null;
                 }
             }


### PR DESCRIPTION
#29 - logging 500s as Information is counter-intuitive.
