### PR TITLE
Added logic to check AllErrors in Context when LogEventLevel is Error

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -201,6 +201,14 @@ namespace SerilogWeb.Classic
                     var error = application.Server.GetLastError();
                     var level = error != null || application.Response.StatusCode >= 500 ? LogEventLevel.Error : _requestLoggingLevel;
 
+                    if (level == LogEventLevel.Error && error == null)
+                    {
+                        if (application.Context.AllErrors.Length > 0)
+                        {
+                            error = application.Context.AllErrors[application.Context.AllErrors.Length - 1];
+                        }
+                    }
+
                     var logger = Logger;
                     if (logger.IsEnabled(_formDataLoggingLevel) && FormLoggingStrategy(application.Context))
                     {

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -201,7 +201,7 @@ namespace SerilogWeb.Classic
                     var error = application.Server.GetLastError();
                     var level = error != null || application.Response.StatusCode >= 500 ? LogEventLevel.Error : _requestLoggingLevel;
 
-                    if (level == LogEventLevel.Error && error == null)
+                    if (level == LogEventLevel.Error && error == null && application.Context.AllErrors != null)
                     {
                         error = application.Context.AllErrors.LastOrDefault();
                     }

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -203,10 +203,7 @@ namespace SerilogWeb.Classic
 
                     if (level == LogEventLevel.Error && error == null)
                     {
-                        if (application.Context.AllErrors.Length > 0)
-                        {
-                            error = application.Context.AllErrors[application.Context.AllErrors.Length - 1];
-                        }
+                        error = application.Context.AllErrors.LastOrDefault();
                     }
 
                     var logger = Logger;


### PR DESCRIPTION
There are some scenarios were application.Server.GetLastError() returns null even though Response.StatusCode is 500. In such cases extra check to get the latest error from Context.AllErrors will help Serilog to log appropriate exception in configured sink.