### PR TITLE
Nuget package metadata update

### DIFF
--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
@@ -6,9 +6,9 @@
     <authors>SerilogWeb Contributors, Serilog Contributors</authors>
     <description>Logs details of System.Web HTTP requests through Serilog.</description>
     <language>en-US</language>
-    <projectUrl>http://github.com/serilog-web/classic</projectUrl>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <iconUrl>http://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
+    <projectUrl>https://github.com/serilog-web/classic</projectUrl>
+    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>https://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
     <tags>serilog logging aspnet</tags>
     <dependencies>
       <dependency id="Serilog" version="2.5.0" />

--- a/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
+++ b/src/SerilogWeb.Classic/SerilogWeb.Classic.nuspec
@@ -10,8 +10,5 @@
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>https://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
     <tags>serilog logging aspnet</tags>
-    <dependencies>
-      <dependency id="Serilog" version="2.5.0" />
-    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
- use HTTPS urls
- remove "dependencies" node because it is generated automatically when generating the `.nupkg` from a `csproj` file