### PR TITLE
GDPR: Do not log when DNT header available

### DIFF
--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostIPEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostIPEnricher.cs
@@ -74,6 +74,12 @@ namespace SerilogWeb.Classic.Enrichers
             if (HttpContextCurrent.Request == null)
                 return;
 
+            string doNotTrackHeader = HttpContextCurrent.Request.Headers.Get("DNT");
+
+            // Should not track when value equals 1
+            if (doNotTrackHeader != null && doNotTrackHeader.Equals("1"))
+                return;
+
             if (string.IsNullOrWhiteSpace(HttpContextCurrent.Request.UserHostAddress))
                 return;
 

--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostNameEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestClientHostNameEnricher.cs
@@ -18,6 +18,8 @@ using Serilog.Events;
 
 namespace SerilogWeb.Classic.Enrichers
 {
+    using System.Web;
+
     /// <summary>
     /// Enrich log events with the Client Host Name.
     /// </summary>
@@ -40,6 +42,12 @@ namespace SerilogWeb.Classic.Enrichers
             if (logEvent == null) throw new ArgumentNullException("logEvent");
 
             if (HttpContextCurrent.Request == null)
+                return;
+
+            string doNotTrackHeader = HttpContextCurrent.Request.Headers.Get("DNT");
+
+            // Should not track when value equals 1
+            if (doNotTrackHeader != null && doNotTrackHeader.Equals("1"))
                 return;
 
             if (string.IsNullOrWhiteSpace(HttpContextCurrent.Request.UserHostName))


### PR DESCRIPTION
When a user has enabled DNT, don't add IP or HostName to logfiles