### PR TITLE
Fix exception with null key in form data

### DIFF
--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
@@ -89,7 +89,17 @@ namespace SerilogWeb.Classic
         /// <param name="value">Value of the pair</param>
         internal string FilterPasswords(string key, string value)
         {
-            if (FilterPasswordsInFormData && key != null && FilteredKeywordsInFormData.Any(keyword => key.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) != -1))
+            if (!FilterPasswordsInFormData)
+            {
+                return value;
+            }
+
+            if (key == null)
+            {
+                return value;
+            }
+
+            if (FilteredKeywordsInFormData.Any(keyword => key.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) != -1))
             {
                 return "********";
             }

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
@@ -89,7 +89,7 @@ namespace SerilogWeb.Classic
         /// <param name="value">Value of the pair</param>
         internal string FilterPasswords(string key, string value)
         {
-            if (FilterPasswordsInFormData && FilteredKeywordsInFormData.Any(keyword => key.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) != -1))
+            if (FilterPasswordsInFormData && key != null && FilteredKeywordsInFormData.Any(keyword => key.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) != -1))
             {
                 return "********";
             }

--- a/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
+++ b/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
@@ -364,6 +364,32 @@ namespace SerilogWeb.Classic.Tests
         }
 
         [Fact]
+        public void LogPostedFormDataHandlesNullKeyWhenFiltered()
+        {
+            var formData = new NameValueCollection
+            {
+                {"Foo","Bar" },
+                {"Qux", "Baz" },
+                {null, "" }
+            };
+
+            SerilogWebClassic.Configure(cfg => cfg
+                .EnableFormDataLogging(forms => forms
+                    .FilterKeywords(new List<string>
+                        {
+                            "NA"
+                        }))
+            );
+
+            TestContext.SimulateForm(formData);
+
+            var formDataProperty = LastEvent.Properties["FormData"];
+            Assert.NotNull(formDataProperty);
+            var expected = formData.ToSerilogNameValuePropertySequence();
+            Assert.Equal(expected.ToString(), formDataProperty.ToString());
+        }
+
+        [Fact]
         public void EnableDisable()
         {
             SerilogWebClassic.Configure(cfg => cfg


### PR DESCRIPTION
fix #62
Fix null reference exception when a posted form contains an additional ampersand at the end ("Name=Value&") because ASP.NET will add an additional entry to the forms collection with a null key.