### PR TITLE
Fix error when accessing HttpContext.Request

### DIFF
--- a/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUserAgentEnricher.cs
+++ b/src/SerilogWeb.Classic/Classic/Enrichers/HttpRequestUserAgentEnricher.cs
@@ -40,13 +40,13 @@ namespace SerilogWeb.Classic.Enrichers
         {
             if (logEvent == null) throw new ArgumentNullException("logEvent");
 
-            if (HttpContext.Current?.Request == null)
+            if (HttpContextCurrent.Request == null)
                 return;
             
-            if (string.IsNullOrWhiteSpace(HttpContext.Current.Request.UserAgent))
+            if (string.IsNullOrWhiteSpace(HttpContextCurrent.Request.UserAgent))
                 return;
 
-            var userAgent = HttpContext.Current.Request.UserAgent;
+            var userAgent = HttpContextCurrent.Request.UserAgent;
             var httpRequestUserAgentProperty = new LogEventProperty(HttpRequestUserAgentPropertyName, new ScalarValue(userAgent));
             logEvent.AddPropertyIfAbsent(httpRequestUserAgentProperty);
         }


### PR DESCRIPTION
`HttpContext.Current.Request` throws an `HttpException` when request is not available (for instance during `App_Start`. 

We have a helper `HttpContextCurrent.Request` that catches this exception so it does not impact callers, but it was not used in the `UserAgent` enricher.

Fixes #1