### PR TITLE
Fixing two null exceptions regarding call to FilterKeywords(keywordBlackList)

### DIFF
--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -249,8 +249,13 @@ namespace SerilogWeb.Classic
             /// </summary>
             /// <param name="keywordBlackList">The black-listed keywords</param>
             /// <returns>A configuration object to allow chaining</returns>
+            /// <exception cref="System.ArgumentNullException"/>
+            /// <exception cref="System.ArgumentException"/>
             public FormDataLoggingConfigurationBuilder FilterKeywords(IEnumerable<string> keywordBlackList)
             {
+                if (keywordBlackList == null) throw new ArgumentNullException(nameof(keywordBlackList));
+                if (keywordBlackList.Contains(null)) throw new ArgumentException($"The {nameof(keywordBlackList)} argument is invalid. Keywords cannot be null.");
+
                 var keywords = new List<string>(keywordBlackList);
                 if (!keywords.Any())
                 {

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -254,7 +254,7 @@ namespace SerilogWeb.Classic
             public FormDataLoggingConfigurationBuilder FilterKeywords(IEnumerable<string> keywordBlackList)
             {
                 if (keywordBlackList == null) throw new ArgumentNullException(nameof(keywordBlackList));
-                if (keywordBlackList.Contains(null)) throw new ArgumentException($"The {nameof(keywordBlackList)} argument is invalid. Keywords cannot be null.");
+                if (keywordBlackList.Contains(null)) throw new ArgumentException($"The parameter is invalid. Keywords cannot be null.", nameof(keywordBlackList));
 
                 var keywords = new List<string>(keywordBlackList);
                 if (!keywords.Any())

--- a/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
+++ b/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
@@ -328,6 +328,43 @@ namespace SerilogWeb.Classic.Tests
         }
 
         [Fact]
+        public void ErrorIfMethodFilterKeywordsCalledWithNullCollection()
+        {
+            Type expectedExceptionType = typeof(ArgumentNullException);
+            string expectedExceptionMessage = "Value cannot be null.\r\nParameter name: keywordBlackList";
+
+            var actualException = Assert.Throws(expectedExceptionType, () =>
+                SerilogWebClassic.Configure(cfg => cfg
+                    .EnableFormDataLogging(forms => forms
+                        .FilterKeywords(null)
+                ))
+            );
+
+            Assert.NotNull(actualException);
+            Assert.IsType(expectedExceptionType, actualException);
+            Assert.Equal(expectedExceptionMessage, actualException.Message);
+        }
+
+        [Fact]
+        public void ErrorIfMethodFilterKeywordsCalledWithCollectionContainingNull()
+        {
+            Type expectedExceptionType = typeof(ArgumentException);
+            string expectedExceptionMessage = "The keywordBlackList argument is invalid. Keywords cannot be null.";
+            string nullKeyword = null;
+
+            var actualException = Assert.Throws(expectedExceptionType, () =>
+                SerilogWebClassic.Configure(cfg => cfg
+                    .EnableFormDataLogging(forms => forms
+                        .FilterKeywords(new[] { nullKeyword })
+                ))
+            );
+
+            Assert.NotNull(actualException);
+            Assert.IsType(expectedExceptionType, actualException);
+            Assert.Equal(expectedExceptionMessage, actualException.Message);
+        }
+
+        [Fact]
         public void PasswordBlackListCanBeCustomized()
         {
             SerilogWebClassic.Configure(cfg => cfg

--- a/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
+++ b/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
@@ -330,10 +330,7 @@ namespace SerilogWeb.Classic.Tests
         [Fact]
         public void ErrorIfMethodFilterKeywordsCalledWithNullCollection()
         {
-            Type expectedExceptionType = typeof(ArgumentNullException);
-            string expectedExceptionMessage = "Value cannot be null.\r\nParameter name: keywordBlackList";
-
-            var actualException = Assert.Throws(expectedExceptionType, () =>
+            var actualException = Assert.Throws<ArgumentNullException>(() =>
                 SerilogWebClassic.Configure(cfg => cfg
                     .EnableFormDataLogging(forms => forms
                         .FilterKeywords(null)
@@ -341,18 +338,15 @@ namespace SerilogWeb.Classic.Tests
             );
 
             Assert.NotNull(actualException);
-            Assert.IsType(expectedExceptionType, actualException);
-            Assert.Equal(expectedExceptionMessage, actualException.Message);
+            Assert.IsType<ArgumentNullException>(actualException);
+            Assert.Equal("Value cannot be null.\r\nParameter name: keywordBlackList", actualException.Message);
         }
 
         [Fact]
         public void ErrorIfMethodFilterKeywordsCalledWithCollectionContainingNull()
         {
-            Type expectedExceptionType = typeof(ArgumentException);
-            string expectedExceptionMessage = "The keywordBlackList argument is invalid. Keywords cannot be null.";
             string nullKeyword = null;
-
-            var actualException = Assert.Throws(expectedExceptionType, () =>
+            var actualException = Assert.Throws<ArgumentException>(() =>
                 SerilogWebClassic.Configure(cfg => cfg
                     .EnableFormDataLogging(forms => forms
                         .FilterKeywords(new[] { nullKeyword })
@@ -360,8 +354,8 @@ namespace SerilogWeb.Classic.Tests
             );
 
             Assert.NotNull(actualException);
-            Assert.IsType(expectedExceptionType, actualException);
-            Assert.Equal(expectedExceptionMessage, actualException.Message);
+            Assert.IsType<ArgumentException>(actualException);
+            Assert.Equal("The parameter is invalid. Keywords cannot be null.\r\nParameter name: keywordBlackList", actualException.Message);
         }
 
         [Fact]
@@ -549,11 +543,11 @@ namespace SerilogWeb.Classic.Tests
                 () =>
                 {
                     App.Context.AddSerilogWebError(error);
-                    
-                   
+
+
                     Assert.Null(App.Server.GetLastError());
                     Assert.NotNull(App.Context.GetLastSerilogWebError());
-                    
+
                     return new FakeHttpResponse();
                 });
 


### PR DESCRIPTION
This PR treats unhandled exceptions when parameter `keywordBlackList` of `FilterKeywords` is null or contains null.

1) Fixes #69 by adding a null-treating guard clause into `FilterKeywords(keywordBlackList)` + xunit test;
2) Also adds another null-treating guard in the same method for parameter null case + xunit test.