### PR TITLE
Request time log level

### DIFF
--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -39,7 +39,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: value,
@@ -73,7 +73,7 @@ namespace SerilogWeb.Classic
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
                     requestLoggingLevel: Config.RequestLoggingLevel,
-                    requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                    requestContextLogLevel: Config.RequestContextLogLevel,
                     requestFilter: value,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,
@@ -101,7 +101,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -123,7 +123,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -145,7 +145,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -167,7 +167,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: value,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -189,7 +189,7 @@ namespace SerilogWeb.Classic
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: value,
                 requestFilter: Config.RequestFilter,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
                 logPostedFormData: Config.LogPostedFormData,
@@ -210,7 +210,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
-                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                requestContextLogLevel: Config.RequestContextLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: value,
                 customLogger: Config.CustomLogger,
@@ -236,7 +236,7 @@ namespace SerilogWeb.Classic
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
                     requestLoggingLevel: Config.RequestLoggingLevel,
-                    requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
+                    requestContextLogLevel: Config.RequestContextLogLevel,
                     requestFilter: Config.RequestFilter,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -39,6 +39,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: value,
@@ -72,6 +73,7 @@ namespace SerilogWeb.Classic
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
                     requestLoggingLevel: Config.RequestLoggingLevel,
+                    requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                     requestFilter: value,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,
@@ -99,6 +101,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -120,6 +123,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -141,6 +145,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -162,6 +167,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: value,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -183,6 +189,7 @@ namespace SerilogWeb.Classic
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: value,
                 requestFilter: Config.RequestFilter,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
                 logPostedFormData: Config.LogPostedFormData,
@@ -203,6 +210,7 @@ namespace SerilogWeb.Classic
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
                 requestLoggingLevel: Config.RequestLoggingLevel,
+                requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: value,
                 customLogger: Config.CustomLogger,
@@ -228,6 +236,7 @@ namespace SerilogWeb.Classic
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
                     requestLoggingLevel: Config.RequestLoggingLevel,
+                    requestElapsedMSLogLevel: Config.RequestElapsedMSLogLevel,
                     requestFilter: Config.RequestFilter,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,

--- a/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
+++ b/src/SerilogWeb.Classic/Classic/ApplicationLifecycleModule.cs
@@ -38,8 +38,7 @@ namespace SerilogWeb.Classic
             get => Config.Logger;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: value,
@@ -72,8 +71,7 @@ namespace SerilogWeb.Classic
                 if (value == null) throw new ArgumentNullException(nameof(value));
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
-                    requestLoggingLevel: Config.RequestLoggingLevel,
-                    requestContextLogLevel: Config.RequestContextLogLevel,
+                    logLevelEvaluator: Config.LogLevelEvaluator,
                     requestFilter: value,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,
@@ -100,8 +98,7 @@ namespace SerilogWeb.Classic
             get => Config.LogPostedFormData;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -122,8 +119,7 @@ namespace SerilogWeb.Classic
             get => Config.FilterPasswordsInFormData;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -144,8 +140,7 @@ namespace SerilogWeb.Classic
             get => Config.FilteredKeywordsInFormData;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -166,8 +161,7 @@ namespace SerilogWeb.Classic
             get => Config.IsEnabled;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: value,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
@@ -184,12 +178,10 @@ namespace SerilogWeb.Classic
         [Obsolete("Obsolete since v4.1 - Use SerilogWebClassic.Configure(cfg => cfg.LogAtLevel(level))")]
         public static LogEventLevel RequestLoggingLevel
         {
-            get => Config.RequestLoggingLevel;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: value,
+                logLevelEvaluator: (httpContext, elapsed) => value,
                 requestFilter: Config.RequestFilter,
-                requestContextLogLevel: Config.RequestContextLogLevel,
                 formDataLoggingLevel: Config.FormDataLoggingLevel,
                 customLogger: Config.CustomLogger,
                 logPostedFormData: Config.LogPostedFormData,
@@ -209,8 +201,7 @@ namespace SerilogWeb.Classic
             get => Config.FormDataLoggingLevel;
             set => SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                 isEnabled: Config.IsEnabled,
-                requestLoggingLevel: Config.RequestLoggingLevel,
-                requestContextLogLevel: Config.RequestContextLogLevel,
+                logLevelEvaluator: Config.LogLevelEvaluator,
                 requestFilter: Config.RequestFilter,
                 formDataLoggingLevel: value,
                 customLogger: Config.CustomLogger,
@@ -235,8 +226,7 @@ namespace SerilogWeb.Classic
                 if (value == null) throw new ArgumentNullException(nameof(value));
                 SerilogWebClassic.Configuration = new SerilogWebClassicConfiguration(
                     isEnabled: Config.IsEnabled,
-                    requestLoggingLevel: Config.RequestLoggingLevel,
-                    requestContextLogLevel: Config.RequestContextLogLevel,
+                    logLevelEvaluator: Config.LogLevelEvaluator,
                     requestFilter: Config.RequestFilter,
                     formDataLoggingLevel: Config.FormDataLoggingLevel,
                     customLogger: Config.CustomLogger,

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
@@ -19,7 +19,7 @@ namespace SerilogWeb.Classic
         internal SerilogWebClassicConfiguration(
             bool isEnabled,
             LogEventLevel requestLoggingLevel,
-            Func<long, LogEventLevel> requestElapsedMSLogLevel,
+            Func<HttpContextBase, TimeSpan, LogEventLevel> requestContextLogLevel,
             Func<HttpContextBase, bool> requestFilter,
             LogEventLevel formDataLoggingLevel,
             ILogger customLogger,
@@ -30,7 +30,7 @@ namespace SerilogWeb.Classic
         {
             IsEnabled = isEnabled;
             RequestLoggingLevel = requestLoggingLevel;
-            RequestElapsedMSLogLevel = requestElapsedMSLogLevel;
+            RequestContextLogLevel = requestContextLogLevel;
             RequestFilter = requestFilter;
             FormDataLoggingLevel = formDataLoggingLevel;
             CustomLogger = customLogger;
@@ -68,7 +68,7 @@ namespace SerilogWeb.Classic
         internal bool IsEnabled { get; }
 
         internal LogEventLevel RequestLoggingLevel { get; }
-        internal Func<long, LogEventLevel> RequestElapsedMSLogLevel { get; }
+        internal Func<HttpContextBase, TimeSpan, LogEventLevel> RequestContextLogLevel { get; }
         internal ILogger CustomLogger { get; }
         internal Func<HttpContextBase, bool> RequestFilter { get; }
 

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
@@ -19,6 +19,7 @@ namespace SerilogWeb.Classic
         internal SerilogWebClassicConfiguration(
             bool isEnabled,
             LogEventLevel requestLoggingLevel,
+            Func<long, LogEventLevel> requestElapsedMSLogLevel,
             Func<HttpContextBase, bool> requestFilter,
             LogEventLevel formDataLoggingLevel,
             ILogger customLogger,
@@ -29,6 +30,7 @@ namespace SerilogWeb.Classic
         {
             IsEnabled = isEnabled;
             RequestLoggingLevel = requestLoggingLevel;
+            RequestElapsedMSLogLevel = requestElapsedMSLogLevel;
             RequestFilter = requestFilter;
             FormDataLoggingLevel = formDataLoggingLevel;
             CustomLogger = customLogger;
@@ -66,6 +68,7 @@ namespace SerilogWeb.Classic
         internal bool IsEnabled { get; }
 
         internal LogEventLevel RequestLoggingLevel { get; }
+        internal Func<long, LogEventLevel> RequestElapsedMSLogLevel { get; }
         internal ILogger CustomLogger { get; }
         internal Func<HttpContextBase, bool> RequestFilter { get; }
 
@@ -78,10 +81,10 @@ namespace SerilogWeb.Classic
 
         internal ILogger Logger => (CustomLogger ?? Log.Logger).ForContext<ApplicationLifecycleModule>();
 
-        
+
         internal Func<HttpContextBase, bool> FormLoggingStrategy { get; }
 
-        
+
         /// <summary>
         /// Filters configured keywords from being logged
         /// </summary>

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfiguration.cs
@@ -18,8 +18,7 @@ namespace SerilogWeb.Classic
 
         internal SerilogWebClassicConfiguration(
             bool isEnabled,
-            LogEventLevel requestLoggingLevel,
-            Func<HttpContextBase, TimeSpan, LogEventLevel> requestContextLogLevel,
+            Func<HttpContextBase, TimeSpan, LogEventLevel> logLevelEvaluator,
             Func<HttpContextBase, bool> requestFilter,
             LogEventLevel formDataLoggingLevel,
             ILogger customLogger,
@@ -29,8 +28,7 @@ namespace SerilogWeb.Classic
             IEnumerable<string> filteredKeywordsInFormData)
         {
             IsEnabled = isEnabled;
-            RequestLoggingLevel = requestLoggingLevel;
-            RequestContextLogLevel = requestContextLogLevel;
+            LogLevelEvaluator = logLevelEvaluator;
             RequestFilter = requestFilter;
             FormDataLoggingLevel = formDataLoggingLevel;
             CustomLogger = customLogger;
@@ -67,8 +65,7 @@ namespace SerilogWeb.Classic
 
         internal bool IsEnabled { get; }
 
-        internal LogEventLevel RequestLoggingLevel { get; }
-        internal Func<HttpContextBase, TimeSpan, LogEventLevel> RequestContextLogLevel { get; }
+        internal Func<HttpContextBase, TimeSpan, LogEventLevel> LogLevelEvaluator { get; }
         internal ILogger CustomLogger { get; }
         internal Func<HttpContextBase, bool> RequestFilter { get; }
 

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -17,8 +17,7 @@ namespace SerilogWeb.Classic
 
         private bool IsEnabled { get; set; } = true;
 
-        private LogEventLevel RequestLoggingLevel { get; set; }
-        private Func<HttpContextBase, TimeSpan, LogEventLevel> RequestContextLogLevel { get; set; }
+        private Func<HttpContextBase, TimeSpan, LogEventLevel> LogLevelEvaluator { get; set; }
         private ILogger CustomLogger { get; set; }
         private Func<HttpContextBase, bool> RequestFilter { get; set; }
 
@@ -39,8 +38,7 @@ namespace SerilogWeb.Classic
             if (configToCopy == null) throw new ArgumentNullException(nameof(configToCopy));
             CustomLogger = configToCopy.CustomLogger;
             IsEnabled = configToCopy.IsEnabled;
-            RequestLoggingLevel = configToCopy.RequestLoggingLevel;
-            RequestContextLogLevel = configToCopy.RequestContextLogLevel;
+            LogLevelEvaluator = configToCopy.LogLevelEvaluator;
             RequestFilter = configToCopy.RequestFilter;
             FormDataLoggingLevel = configToCopy.FormDataLoggingLevel;
             LogPostedFormData = configToCopy.LogPostedFormData;
@@ -53,7 +51,7 @@ namespace SerilogWeb.Classic
         {
             CustomLogger = null;
             IsEnabled = true;
-            RequestLoggingLevel = LogEventLevel.Information;
+            LogLevelEvaluator = (ctx, elapsed) => LogEventLevel.Information;
             RequestFilter = AlwaysFalse;
             ResetFormDataLogging();
         }
@@ -71,8 +69,7 @@ namespace SerilogWeb.Classic
         {
             return new SerilogWebClassicConfiguration(
                 isEnabled: IsEnabled,
-                requestLoggingLevel: RequestLoggingLevel,
-                requestContextLogLevel: RequestContextLogLevel,
+                logLevelEvaluator: LogLevelEvaluator,
                 requestFilter: RequestFilter,
                 formDataLoggingLevel: FormDataLoggingLevel,
                 customLogger: CustomLogger,
@@ -112,19 +109,18 @@ namespace SerilogWeb.Classic
         /// <returns>A configuration object to allow chaining</returns>
         public SerilogWebClassicConfigurationBuilder LogAtLevel(LogEventLevel level)
         {
-            RequestLoggingLevel = level;
+            LogLevelEvaluator = (ctx, elapsed) => level;
             return this;
         }
 
         /// <summary>
-        /// Configure at which level HTTP requests are logged.
-        /// Default is Information
+        /// Configure at which level HTTP requests are logged dynamically depending on the context
         /// </summary>
-        /// <param name="requestContextLogLevel">Override the default log level based on the current http context and total request time</param>
+        /// <param name="logLevelEvaluator">Set the log level based on the current http context and total request time</param>
         /// <returns>A configuration object to allow chaining</returns>
-        public SerilogWebClassicConfigurationBuilder LogAtLevel(Func<HttpContextBase, TimeSpan, LogEventLevel> requestContextLogLevel)
+        public SerilogWebClassicConfigurationBuilder LogAtLevel(Func<HttpContextBase, TimeSpan, LogEventLevel> logLevelEvaluator)
         {
-            RequestContextLogLevel = requestContextLogLevel;
+            LogLevelEvaluator = logLevelEvaluator;
             return this;
         }
 

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -18,6 +18,7 @@ namespace SerilogWeb.Classic
         private bool IsEnabled { get; set; } = true;
 
         private LogEventLevel RequestLoggingLevel { get; set; }
+        private Func<long, LogEventLevel> RequestElapsedMSLogLevel { get; set; }
         private ILogger CustomLogger { get; set; }
         private Func<HttpContextBase, bool> RequestFilter { get; set; }
 
@@ -39,6 +40,7 @@ namespace SerilogWeb.Classic
             CustomLogger = configToCopy.CustomLogger;
             IsEnabled = configToCopy.IsEnabled;
             RequestLoggingLevel = configToCopy.RequestLoggingLevel;
+            RequestElapsedMSLogLevel = configToCopy.RequestElapsedMSLogLevel;
             RequestFilter = configToCopy.RequestFilter;
             FormDataLoggingLevel = configToCopy.FormDataLoggingLevel;
             LogPostedFormData = configToCopy.LogPostedFormData;
@@ -70,6 +72,7 @@ namespace SerilogWeb.Classic
             return new SerilogWebClassicConfiguration(
                 isEnabled: IsEnabled,
                 requestLoggingLevel: RequestLoggingLevel,
+                requestElapsedMSLogLevel: RequestElapsedMSLogLevel,
                 requestFilter: RequestFilter,
                 formDataLoggingLevel: FormDataLoggingLevel,
                 customLogger: CustomLogger,
@@ -110,6 +113,21 @@ namespace SerilogWeb.Classic
         public SerilogWebClassicConfigurationBuilder LogAtLevel(LogEventLevel level)
         {
             RequestLoggingLevel = level;
+            return this;
+        }
+
+        /// <summary>
+        /// Configure at which level HTTP requests are logged.
+        /// Default is Information
+        /// </summary>
+        /// <param name="level">The level to override the default value</param>
+        /// <param name="requestElapsedMSLogLevel">Override the default log level based on the total request time in milliseconds</param>
+        /// <returns>A configuration object to allow chaining</returns>
+        public SerilogWebClassicConfigurationBuilder LogAtLevel(LogEventLevel level, Func<long, LogEventLevel> requestElapsedMSLogLevel)
+        {
+            RequestLoggingLevel = level;
+            RequestElapsedMSLogLevel = requestElapsedMSLogLevel;
+
             return this;
         }
 

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -120,14 +120,11 @@ namespace SerilogWeb.Classic
         /// Configure at which level HTTP requests are logged.
         /// Default is Information
         /// </summary>
-        /// <param name="level">The level to override the default value</param>
         /// <param name="requestElapsedMSLogLevel">Override the default log level based on the total request time in milliseconds</param>
         /// <returns>A configuration object to allow chaining</returns>
-        public SerilogWebClassicConfigurationBuilder LogAtLevel(LogEventLevel level, Func<long, LogEventLevel> requestElapsedMSLogLevel)
+        public SerilogWebClassicConfigurationBuilder LogAtLevel(Func<long, LogEventLevel> requestElapsedMSLogLevel)
         {
-            RequestLoggingLevel = level;
             RequestElapsedMSLogLevel = requestElapsedMSLogLevel;
-
             return this;
         }
 

--- a/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
+++ b/src/SerilogWeb.Classic/Classic/SerilogWebClassicConfigurationBuilder.cs
@@ -18,7 +18,7 @@ namespace SerilogWeb.Classic
         private bool IsEnabled { get; set; } = true;
 
         private LogEventLevel RequestLoggingLevel { get; set; }
-        private Func<long, LogEventLevel> RequestElapsedMSLogLevel { get; set; }
+        private Func<HttpContextBase, TimeSpan, LogEventLevel> RequestContextLogLevel { get; set; }
         private ILogger CustomLogger { get; set; }
         private Func<HttpContextBase, bool> RequestFilter { get; set; }
 
@@ -40,7 +40,7 @@ namespace SerilogWeb.Classic
             CustomLogger = configToCopy.CustomLogger;
             IsEnabled = configToCopy.IsEnabled;
             RequestLoggingLevel = configToCopy.RequestLoggingLevel;
-            RequestElapsedMSLogLevel = configToCopy.RequestElapsedMSLogLevel;
+            RequestContextLogLevel = configToCopy.RequestContextLogLevel;
             RequestFilter = configToCopy.RequestFilter;
             FormDataLoggingLevel = configToCopy.FormDataLoggingLevel;
             LogPostedFormData = configToCopy.LogPostedFormData;
@@ -72,7 +72,7 @@ namespace SerilogWeb.Classic
             return new SerilogWebClassicConfiguration(
                 isEnabled: IsEnabled,
                 requestLoggingLevel: RequestLoggingLevel,
-                requestElapsedMSLogLevel: RequestElapsedMSLogLevel,
+                requestContextLogLevel: RequestContextLogLevel,
                 requestFilter: RequestFilter,
                 formDataLoggingLevel: FormDataLoggingLevel,
                 customLogger: CustomLogger,
@@ -120,11 +120,11 @@ namespace SerilogWeb.Classic
         /// Configure at which level HTTP requests are logged.
         /// Default is Information
         /// </summary>
-        /// <param name="requestElapsedMSLogLevel">Override the default log level based on the total request time in milliseconds</param>
+        /// <param name="requestContextLogLevel">Override the default log level based on the current http context and total request time</param>
         /// <returns>A configuration object to allow chaining</returns>
-        public SerilogWebClassicConfigurationBuilder LogAtLevel(Func<long, LogEventLevel> requestElapsedMSLogLevel)
+        public SerilogWebClassicConfigurationBuilder LogAtLevel(Func<HttpContextBase, TimeSpan, LogEventLevel> requestContextLogLevel)
         {
-            RequestElapsedMSLogLevel = requestElapsedMSLogLevel;
+            RequestContextLogLevel = requestContextLogLevel;
             return this;
         }
 

--- a/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
+++ b/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
@@ -44,7 +44,9 @@ namespace SerilogWeb.Classic
 
             var error = _application.Context.GetLastSerilogWebError() ?? _application.Server.GetLastError();
 
-            var level = error != null || _application.Response.StatusCode >= 500 ? LogEventLevel.Error : configuration.RequestLoggingLevel;
+            var configurationLevel = configuration.RequestElapsedMSLogLevel != null ? configuration.RequestElapsedMSLogLevel(stopwatch.ElapsedMilliseconds) : configuration.RequestLoggingLevel;
+
+            var level = error != null || _application.Response.StatusCode >= 500 ? LogEventLevel.Error : configurationLevel;
 
             if (level == LogEventLevel.Error && error == null && _application.Context.AllErrors != null)
             {

--- a/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
+++ b/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
@@ -44,9 +44,7 @@ namespace SerilogWeb.Classic
 
             var error = _application.Context.GetLastSerilogWebError() ?? _application.Server.GetLastError();
 
-            var configurationLevel = configuration.RequestContextLogLevel != null ? configuration.RequestContextLogLevel(_application.Context, stopwatch.Elapsed) : configuration.RequestLoggingLevel;
-
-            var level = error != null || _application.Response.StatusCode >= 500 ? LogEventLevel.Error : configurationLevel;
+            var level = error != null || _application.Response.StatusCode >= 500 ? LogEventLevel.Error : configuration.LogLevelEvaluator(_application.Context, stopwatch.Elapsed);
 
             if (level == LogEventLevel.Error && error == null && _application.Context.AllErrors != null)
             {

--- a/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
+++ b/src/SerilogWeb.Classic/Classic/WebRequestLoggingHandler.cs
@@ -44,7 +44,7 @@ namespace SerilogWeb.Classic
 
             var error = _application.Context.GetLastSerilogWebError() ?? _application.Server.GetLastError();
 
-            var configurationLevel = configuration.RequestElapsedMSLogLevel != null ? configuration.RequestElapsedMSLogLevel(stopwatch.ElapsedMilliseconds) : configuration.RequestLoggingLevel;
+            var configurationLevel = configuration.RequestContextLogLevel != null ? configuration.RequestContextLogLevel(_application.Context, stopwatch.Elapsed) : configuration.RequestLoggingLevel;
 
             var level = error != null || _application.Response.StatusCode >= 500 ? LogEventLevel.Error : configurationLevel;
 

--- a/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
+++ b/test/SerilogWeb.Classic.Tests/WebRequestLoggingHandlerTests.cs
@@ -86,6 +86,40 @@ namespace SerilogWeb.Classic.Tests
             Assert.Equal(requestLoggingLevel, evt.Level);
         }
 
+        [Theory]
+        [InlineData(LogEventLevel.Verbose)]
+        [InlineData(LogEventLevel.Debug)]
+        [InlineData(LogEventLevel.Information)]
+        [InlineData(LogEventLevel.Warning)]
+        [InlineData(LogEventLevel.Error)]
+        [InlineData(LogEventLevel.Fatal)]
+        public void RequestLogLevelEvaluator(LogEventLevel requestLoggingLevel)
+        {
+            SerilogWebClassic.Configure(cfg => cfg
+                .LogAtLevel((context, elapsed) => requestLoggingLevel)
+            );
+
+            TestContext.SimulateRequest();
+
+            var evt = LastEvent;
+            Assert.NotNull(evt);
+            Assert.Equal(requestLoggingLevel, evt.Level);
+        }
+
+        [Fact]
+        public void DynamicRequestLogLevelEvaluator()
+        {
+            SerilogWebClassic.Configure(cfg => cfg
+                .LogAtLevel((context, elapsed) => elapsed.TotalMilliseconds > 3000 ? LogEventLevel.Warning : LogEventLevel.Information)
+            );
+
+            TestContext.SimulateRequest(sleepDurationMilliseconds: 4000);
+
+            var evt = LastEvent;
+            Assert.NotNull(evt);
+            Assert.Equal(LogEventLevel.Warning, evt.Level);
+        }
+
         [Fact]
         public void LogPostedFormData()
         {


### PR DESCRIPTION
It would be nice if it was possible to configure the log level based off of the total request time.

For example:

Request time < 300ms --> verbose
Request time < 1000ms --> info
Request time < 5000 ms --> warning
etc.

These changes should achieve that.
